### PR TITLE
Fixed missing libssl-dev dependency

### DIFF
--- a/Setup/Setup.sh
+++ b/Setup/Setup.sh
@@ -31,7 +31,7 @@ sleep 2
 # Install_Missing_APT_Packages
 echo -e "Installing the missing ${RED}apt packages${NOCOLOR}"
 echo -e "${CYAN}-----------------------------------------------------------------${NOCOLOR}\n"
-sudo apt install -y libcurl4-openssl-dev chromium chromium-driver python3-pip python3-venv
+sudo apt install -y libcurl4-openssl-dev libssl-dev chromium chromium-driver python3-pip python3-venv
 echo -e "\n\nThe ${RED}apt packages${NOCOLOR} was installed!\n"
 echo -e "${CYAN}-----------------------------------------------------------------${NOCOLOR}\n\n\n"
 


### PR DESCRIPTION
On a freshly installed Kali Linux, `libssl-dev` is not installed. As a result, building the wheel for `pycurl` will fail due to a missing include file:
![2024-06-06_12-41](https://github.com/HomeSen/Einherjer/assets/663748/a0d47d61-3716-4424-93fb-f762baf12dd3)
